### PR TITLE
Handling ":" better in feature parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ Jcrfsuite is a Java interface of [crfsuite](http://www.chokkan.org/software/crfs
 To build, you need to install Maven, then run
 
 <pre>
-mvn package
+mvn clean package
 </pre>
 	
 ### 2) Training
 To train a POS model from Twitter POS data, run
 
 <pre>
-java -cp target/jcrfsuite-0.1.jar com.github.jcrfsuite.example.Train example/tweet-pos/train-oct27.txt twitter-pos.model
+java -cp target/jcrfsuite-*.jar com.github.jcrfsuite.example.Train example/tweet-pos/train-oct27.txt twitter-pos.model
 </pre>
 	
 ### 3) Tagging
 To test the trained POS model against the test set, run
 
 <pre>
-java -cp target/jcrfsuite-0.1.jar com.github.jcrfsuite.example.Tag twitter-pos.model example/tweet-pos/test-daily547.txt 
+java -cp target/jcrfsuite-*.jar com.github.jcrfsuite.example.Tag twitter-pos.model example/tweet-pos/test-daily547.txt
 </pre>
 	
 The output should be as follows:
@@ -40,7 +40,7 @@ $       $       1.00
 N       N       0.99
 U       U       1.00
 
-Accuracy = 92.97%
+Accuracy = 92.99%
 </pre>
 
 Note that the accuracy might be slightly different than in the above output.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.jcrfsuite</groupId>
 	<artifactId>jcrfsuite</artifactId>
-	<version>0.4</version>
+	<version>0.5</version>
 	<name>Crfsuite for Java</name>
 	<packaging>jar</packaging>
 	<url>http://maven.apache.org</url>

--- a/src/main/java/com/github/jcrfsuite/CrfTrainer.java
+++ b/src/main/java/com/github/jcrfsuite/CrfTrainer.java
@@ -58,9 +58,14 @@ public class CrfTrainer {
 						String field = fields[i];
 						String[] colonSplit = field.split(":", 2);
 						if (colonSplit.length == 2) {
-							// the feature has a scaling value
-							double val = Double.valueOf(colonSplit[1]);
-							item.add(new Attribute(colonSplit[0], val));
+							try {
+								// See if the feature has a scaling value.
+								double val = Double.valueOf(colonSplit[1]);
+								item.add(new Attribute(colonSplit[0], val));
+							} catch (NumberFormatException e) {
+								// There was no scaling value.
+								item.add(new Attribute(field));
+							}
 						} else {
 							item.add(new Attribute(field));
 						}

--- a/src/main/java/com/github/jcrfsuite/example/Tag.java
+++ b/src/main/java/com/github/jcrfsuite/example/Tag.java
@@ -16,6 +16,13 @@ import com.github.jcrfsuite.util.Pair;
  */
 public class Tag {
 
+	/**
+	 * Tag the sequences in a file.
+	 * 
+	 * @param args
+	 *			Model file, test file.
+	 * @throws IOException
+	 */
 	public static void main(String[] args) throws IOException {
 		if (args.length != 2) {
 			System.out.println("Usage: " + Tag.class.getCanonicalName() + " <model file> <test file>");

--- a/src/main/java/com/github/jcrfsuite/example/Train.java
+++ b/src/main/java/com/github/jcrfsuite/example/Train.java
@@ -12,6 +12,13 @@ import com.github.jcrfsuite.CrfTrainer;
  */
 public class Train {
 
+	/**
+	 * Train using the sequences in a file.
+	 * 
+	 * @param args
+	 *			Training file, model file.
+	 * @throws IOException
+	 */
 	public static void main(String[] args) throws IOException {
 		if (args.length != 2) {
 			System.out.println("Usage: " + Train.class.getCanonicalName() + " <train file> <model file>");

--- a/src/test/java/com/github/jcrfsuite/CrfTrainerTest.java
+++ b/src/test/java/com/github/jcrfsuite/CrfTrainerTest.java
@@ -13,6 +13,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import third_party.org.chokkan.crfsuite.ItemSequence;
+import third_party.org.chokkan.crfsuite.StringList;
+
 import com.github.jcrfsuite.util.Pair;
 
 public class CrfTrainerTest {
@@ -43,6 +46,29 @@ public class CrfTrainerTest {
 	}
 
 	@Test
+	public void testLoad() throws IOException {
+		Pair<List<ItemSequence>, List<StringList>> trainingInstances =
+				CrfTrainer.loadTrainingInstances(TRAINING_DATA_PATH.toString());
+		List<ItemSequence> sequences = trainingInstances.getFirst();
+
+		List<StringList> labels = trainingInstances.getSecond();
+		// It's hard to make nice tests since ItemSequence doesn't implement equals
+
+		assertThat(sequences.get(0).get(0).get(0).getAttr(), equalTo("test"));
+		assertThat(sequences.get(0).get(0).get(0).getValue(), equalTo(1d));
+		assertThat(labels.get(0).get(0), equalTo("TEST"));
+		assertThat(labels.get(0).get(1), equalTo("O"));
+
+		assertThat(sequences.get(3).get(0).get(0).getAttr(), equalTo("test:"));
+		assertThat(sequences.get(3).get(0).get(0).getValue(), equalTo(1d));
+		assertThat(labels.get(3).get(0), equalTo("TEST"));
+
+		assertThat(sequences.get(4).get(0).get(0).getAttr(), equalTo("something:test"));
+		assertThat(sequences.get(4).get(0).get(0).getValue(), equalTo(1d));
+		assertThat(labels.get(4).get(0), equalTo("O"));
+	}
+
+	@Test
 	public void testTrainStringString() throws IOException {
 		String trainingDataPathString = TRAINING_DATA_PATH.toString();
 		String modelPathString = MODEL_PATH.toString();
@@ -56,7 +82,7 @@ public class CrfTrainerTest {
 
 		List<List<Pair<String, Double>>> tagging = tagger.tag(trainingDataPathString);
 		// Make sure all got tagged.
-		assertThat(tagging, hasSize(3));
+		assertThat(tagging, hasSize(5));
 
 		// Using ugly explicit tests to use closeTo.
 		List<Pair<String, Double>> firstTest = tagging.get(0);

--- a/src/test/java/com/github/jcrfsuite/example/TrainTagExampleTest.java
+++ b/src/test/java/com/github/jcrfsuite/example/TrainTagExampleTest.java
@@ -1,0 +1,53 @@
+package com.github.jcrfsuite.example;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the example.
+ * 
+ * @author Justin Harris (github.com/juharris)
+ */
+public class TrainTagExampleTest {
+
+	private static final Path TRAINING_FOLDER = Paths.get(System.getProperty("user.dir"))
+			.resolve("src")
+			.resolve("test")
+			.resolve("resources")
+			.resolve("com")
+			.resolve("github")
+			.resolve("jcrfsuite")
+			.resolve("trainer");
+
+	private static final Path MODEL_PATH = TRAINING_FOLDER.resolve("twitter-pos.model");
+
+	@Before
+	public void setUpTest() throws IOException {
+		// Delete the model to make sure we make a new one.
+		Files.deleteIfExists(MODEL_PATH);
+	}
+
+	@After
+	public void teardownTest() throws IOException {
+		// Delete the model to make sure we make a new one next time and to make extra sure it's not commited.
+		Files.deleteIfExists(MODEL_PATH);
+	}
+
+	@Test
+	public void testMain() throws IOException {
+		Train.main(new String[] {
+				"example/tweet-pos/train-oct27.txt",
+				MODEL_PATH.toString()
+		});
+		Tag.main(new String[] {
+				MODEL_PATH.toString(),
+				"example/tweet-pos/test-daily547.txt"
+		});
+	}
+}

--- a/src/test/resources/com/github/jcrfsuite/trainer/.gitignore
+++ b/src/test/resources/com/github/jcrfsuite/trainer/.gitignore
@@ -1,2 +1,3 @@
 # Ignore trained models from tests.
 /*.crfsuite
+twitter-pos.model

--- a/src/test/resources/com/github/jcrfsuite/trainer/test_Jcrfsuite_training_data.tsv
+++ b/src/test/resources/com/github/jcrfsuite/trainer/test_Jcrfsuite_training_data.tsv
@@ -4,3 +4,7 @@ O	nothing
 TEST	test:3
 
 TEST	test	test	test
+
+TEST	test:
+
+O	something:test


### PR DESCRIPTION
- Handling "`:`" better in feature parsing when there is no double following it - if there is a double, it will be used as a scaling value, as per the [CRFsuite docs](http://www.chokkan.org/software/crfsuite/manual.html), otherwise the entire field (even the colon and whatever is after it) is treated as a feature, as was expected in the example.
- Added loading tests.
- Updated README
- Added tests for the examples in README
- Bumped to version 0.5

Corrects issue #4 
